### PR TITLE
Fix bugs and enhance logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
                 </div>
                 
                 <!-- 外部サイト表示用iframe -->
-                <iframe class="site-frame hidden" id="siteFrame" sandbox="allow-scripts allow-same-origin allow-popups allow-forms" referrerpolicy="no-referrer"></iframe>
+                <iframe class="site-frame hidden" id="siteFrame" sandbox="allow-scripts allow-popups allow-forms" referrerpolicy="no-referrer"></iframe>
                 
                 <!-- ローディング表示 -->
                 <div class="loading-overlay hidden" id="loadingOverlay">

--- a/js/features/privacy.js
+++ b/js/features/privacy.js
@@ -311,6 +311,41 @@ class PrivacyManager {
     }
 
     /**
+     * Clear existing data when (re)entering privacy mode.
+     * This is lighter than clearAllData() and targets volatile artefacts
+     * from the previous browsing session while preserving essential
+     * Umbra settings where appropriate.
+     */
+    clearExistingData() {
+        try {
+            // Always purge in-memory session artefacts first
+            this.clearSessionData();
+
+            // Session/local storage
+            if (this.privacySettings.clearSessionStorage) {
+                this.clearSessionStorage();
+            }
+
+            // Only clear localStorage when user explicitly opted-in via settings
+            if (this.privacySettings.clearLocalStorage && this.privacySettings.clearOnExit) {
+                this.clearLocalStorage();
+            }
+
+            // Cookies
+            if (this.privacySettings.clearCookies) {
+                this.clearCookies();
+            }
+
+            // Cache (service-workers / HTTP-cache)
+            this.clearCache();
+
+            console.log('Existing data cleared for fresh privacy session');
+        } catch (error) {
+            console.warn('Failed to clear existing data:', error);
+        }
+    }
+
+    /**
      * Clear browsing history
      */
     clearHistory() {


### PR DESCRIPTION
Fixes `TypeError` on browser initialization and resolves iframe sandbox security warning.

The `TypeError: this.clearExistingData is not a function` occurred because `PrivacyManager.enablePrivacyMode` was calling a non-existent method. This PR implements `clearExistingData()` to provide a targeted data clearing mechanism for privacy mode, addressing the error. Additionally, the `allow-same-origin` attribute was removed from the iframe's sandbox to mitigate a security warning about potential sandbox escapes when combined with `allow-scripts`.